### PR TITLE
service: Support only ROSA STS

### DIFF
--- a/cmd/create/service/cmd.go
+++ b/cmd/create/service/cmd.go
@@ -37,8 +37,9 @@ import (
 var args ocm.CreateManagedServiceArgs
 
 var Cmd = &cobra.Command{
-	Use:   "service",
-	Short: "Creates a managed service.",
+	Use:     "service",
+	Aliases: []string{"appliance"},
+	Short:   "Creates a managed service.",
 	Long: `  Managed Services are OpenShift clusters that provide a specific function.
   Use this command to create managed services.`,
 	Example: `  # Create a Managed Service of type service1.

--- a/cmd/create/service/cmd.go
+++ b/cmd/create/service/cmd.go
@@ -26,10 +26,12 @@ import (
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/info"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/output"
+	"github.com/openshift/rosa/pkg/properties"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
 )
 
@@ -196,6 +198,12 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
+	args.AwsAccountID = awsCreator.AccountID
+	args.Properties = map[string]string{
+		properties.CreatorARN: awsCreator.ARN,
+		properties.CLIVersion: info.Version,
+	}
+
 	operatorRolesPrefix := getRolePrefix(args.ClusterName)
 	operatorIAMRoleList := []ocm.OperatorIAMRole{}
 
@@ -230,25 +238,6 @@ func run(cmd *cobra.Command, _ []string) {
 
 	args.AwsOperatorIamRoleList = operatorIAMRoleList
 	// end operator role logic.
-
-	/*
-		awsCreator, err := awsClient.GetCreator()
-		if err != nil {
-			reporter.Errorf("Unable to get IAM credentials: %v", err)
-			os.Exit(1)
-		}
-
-		accessKey, err := awsClient.GetAWSAccessKeys()
-		if err != nil {
-			reporter.Errorf("Unable to get access keys: %v", err)
-			os.Exit(1)
-		}
-		args.AwsAccountID = awsCreator.AccountID
-		args.AwsAccessKeyID = accessKey.AccessKeyID
-		args.AwsSecretAccessKey = accessKey.SecretAccessKey
-	*/
-
-	args.AwsAccountID = awsCreator.AccountID
 
 	// Get AWS region
 	args.AwsRegion, err = aws.GetRegion("")

--- a/pkg/ocm/managedservice.go
+++ b/pkg/ocm/managedservice.go
@@ -10,10 +10,9 @@ type CreateManagedServiceArgs struct {
 	ClusterName string
 
 	Parameters map[string]string
+	Properties map[string]string
 
 	AwsAccountID           string
-	AwsAccessKeyID         string
-	AwsSecretAccessKey     string
 	AwsRoleARN             string
 	AwsSupportRoleARN      string
 	AwsControlPlaneRoleARN string
@@ -46,6 +45,7 @@ func (c *Client) CreateManagedService(args CreateManagedServiceArgs) (*msv1.Mana
 		Cluster(
 			msv1.NewCluster().
 				Name(args.ClusterName).
+				Properties(args.Properties).
 				Region(
 					msv1.NewCloudRegion().
 						ID(args.AwsRegion)).
@@ -58,9 +58,7 @@ func (c *Client) CreateManagedService(args CreateManagedServiceArgs) (*msv1.Mana
 								MasterRoleARN(args.AwsControlPlaneRoleARN).
 								WorkerRoleARN(args.AwsWorkerRoleARN)).
 							OperatorIAMRoles(operatorIamRoles...)).
-						AccountID(args.AwsAccountID).
-						AccessKeyID(args.AwsAccessKeyID).
-						SecretAccessKey(args.AwsSecretAccessKey))).
+						AccountID(args.AwsAccountID))).
 		Build()
 
 	if err != nil {


### PR DESCRIPTION
Since we're only supporting ROSA, we need the required cluster
properties to show that it's a ROSA cluster. Additionally, since it's
a new service, we should be supporting only the STS cluster flow and
start deprecating IAM-based credentials.